### PR TITLE
Fix CI concurrency cancelling PRs; migrate web tests to Vitest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,15 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    # Deploys must serialize on a single shared slot, but non-master runs only
+    # build and test — they share no state, so they must not queue against it.
+    # A global group made every PR contend for `deploy-dev`, and a queued run
+    # evicts another queued run regardless of cancel-in-progress, so batches of
+    # Dependabot PRs cancelled each other with "a higher priority waiting
+    # request for deploy-dev exists".
     concurrency:
-      group: deploy-dev
-      cancel-in-progress: false
+      group: ${{ github.ref == 'refs/heads/master' && 'deploy-dev' || format('ci-{0}', github.ref) }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
     steps:
       - name: Checkout ${{ github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,33 +1,22 @@
+# Structured to match the centrally managed templates:
+# https://github.com/domdomegg/domdomegg/blob/master/file-sync/node-gh-pages.yaml
+# Kept as a bespoke file because this repo deploys two things from one commit —
+# the server to AWS Lambda and the web build to GitHub Pages — which neither
+# template covers.
+
 name: ci
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
 
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Only master pushes deploy, and only the deploys need these permissions —
-    # id-token to mint the GitHub OIDC token used to assume the AWS role (the
-    # role trust is pinned to this repo's master ref in aws-shared-infra), and
-    # contents to push the web build to the gh-pages branch. Build+deploy share
-    # this job, so the job carries the permissions.
-    permissions:
-      id-token: write
-      contents: write
-    # Deploys must serialize on a single shared slot, but non-master runs only
-    # build and test — they share no state, so they must not queue against it.
-    # A global group made every PR contend for `deploy-dev`, and a queued run
-    # evicts another queued run regardless of cancel-in-progress, so batches of
-    # Dependabot PRs cancelled each other with "a higher priority waiting
-    # request for deploy-dev exists".
-    concurrency:
-      group: ${{ github.ref == 'refs/heads/master' && 'deploy-dev' || format('ci-{0}', github.ref) }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
-
+    env:
+      CI: true
     steps:
       - name: Checkout ${{ github.sha }}
         uses: actions/checkout@v4
@@ -40,26 +29,54 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Lint
-        run: npm run lint
+        run: npm run lint --if-present
       - name: Build
-        run: npm run build
+        run: npm run build --if-present
       - name: Test
-        run: npm run test
+        run: npm run test --if-present
+
+  # Split from ci so that the deploy concurrency group below applies only to
+  # master. While both lived in one job, every PR joined the deploy group and
+  # batches of Dependabot PRs evicted each other from the queue — a queued run
+  # displaces another queued run regardless of cancel-in-progress.
+  deploy:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    needs: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # id-token mints the GitHub OIDC token used to assume the AWS role (trust is
+    # pinned to this repo's master ref in aws-shared-infra); contents pushes the
+    # web build to the gh-pages branch.
+    permissions:
+      id-token: write
+      contents: write
+    concurrency:
+      group: deploy-dev
+      cancel-in-progress: false
+    env:
+      CI: true
+    steps:
+      - name: Checkout ${{ github.sha }}
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
 
       # Deployment to dev environment (server)
       - name: "server: Retrieve env for dev environment"
-        if: github.ref == 'refs/heads/master'
         run: echo "$DEV_ENV" > server/src/env/dev.ts
         env:
           DEV_ENV: ${{ secrets.DEV_ENV }}
       - name: Configure AWS credentials (OIDC)
-        if: github.ref == 'refs/heads/master'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::338337944728:role/postal-vote-ci
           aws-region: eu-west-1
       - name: "server: Deploy to dev environment"
-        if: github.ref == 'refs/heads/master'
         run: npm run deploy:dev
         working-directory: server
 
@@ -67,11 +84,9 @@ jobs:
       # longer a dev web deploy: postal-vote-dev is archived and the GH_PAT
       # secret it relied on no longer exists.
       - name: "web: Build for prod environment"
-        if: github.ref == 'refs/heads/master'
         run: npm run build:prod
         working-directory: web
       - name: "web: Deploy to prod environment"
-        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,27 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/@aws-sdk/checksums": {
             "version": "3.1000.12",
             "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.12.tgz",
@@ -2925,6 +2946,121 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@csstools/normalize.css": {
@@ -6181,9 +6317,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -6313,9 +6449,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -6330,9 +6466,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -6347,9 +6483,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -6364,9 +6500,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -6381,9 +6517,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -6398,9 +6534,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -6418,9 +6554,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
             ],
@@ -6438,9 +6574,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
             ],
@@ -6458,9 +6594,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
             ],
@@ -6478,9 +6614,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
             ],
@@ -6498,9 +6634,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
             ],
@@ -6518,9 +6654,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -6535,9 +6671,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -6554,9 +6690,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -6571,9 +6707,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -8279,16 +8415,16 @@
             "license": "ISC"
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -8297,9 +8433,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8310,13 +8446,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.9",
+                "@vitest/utils": "4.1.10",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -8324,14 +8460,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -8340,9 +8476,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -8350,13 +8486,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -20621,9 +20757,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -21683,9 +21819,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -21702,7 +21838,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -24915,13 +25051,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -24931,21 +25067,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/rollup": {
@@ -25023,6 +25159,13 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
             "dev": true,
             "license": "MIT"
         },
@@ -27690,6 +27833,26 @@
                 "tlds": "bin.js"
             }
         },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -28601,19 +28764,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.9",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/runner": "4.1.9",
-                "@vitest/snapshot": "4.1.9",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -28641,12 +28804,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.9",
-                "@vitest/browser-preview": "4.1.9",
-                "@vitest/browser-webdriverio": "4.1.9",
-                "@vitest/coverage-istanbul": "4.1.9",
-                "@vitest/coverage-v8": "4.1.9",
-                "@vitest/ui": "4.1.9",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -28691,13 +28854,13 @@
             }
         },
         "node_modules/vitest/node_modules/@vitest/mocker": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.9",
+                "@vitest/spy": "4.1.10",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -28741,16 +28904,16 @@
             }
         },
         "node_modules/vitest/node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -30655,8 +30818,6 @@
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.3.0",
                 "@testing-library/user-event": "^14.4.2",
-                "@types/jest": "^28.1.6",
-                "@types/node": "^18.6.5",
                 "@types/react": "^18.0.17",
                 "@types/react-dom": "^18.0.6",
                 "@types/styled-components": "^5.1.25",
@@ -30672,7 +30833,11 @@
                 "typescript": "^5.4.5"
             },
             "devDependencies": {
-                "shx": "^0.3.4"
+                "@types/node": "^22.20.1",
+                "@vitejs/plugin-react": "^6.0.4",
+                "jsdom": "^26.1.0",
+                "shx": "^0.3.4",
+                "vitest": "^4.1.10"
             }
         },
         "web/node_modules/@eslint/eslintrc": {
@@ -30724,12 +30889,13 @@
             "peer": true
         },
         "web/node_modules/@types/node": {
-            "version": "18.19.130",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.21.0"
             }
         },
         "web/node_modules/@typescript-eslint/eslint-plugin": {
@@ -30885,6 +31051,32 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "web/node_modules/@vitejs/plugin-react": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+            "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+                "babel-plugin-react-compiler": "^1.0.0",
+                "vite": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rolldown/plugin-babel": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
+                    "optional": true
+                }
+            }
+        },
         "web/node_modules/acorn": {
             "version": "8.17.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -30896,6 +31088,16 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "web/node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
             }
         },
         "web/node_modules/ajv": {
@@ -30946,6 +31148,47 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "web/node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "web/node_modules/eslint": {
@@ -31166,6 +31409,60 @@
                 "node": ">=10.13.0"
             }
         },
+        "web/node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "web/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "web/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "web/node_modules/js-yaml": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
@@ -31187,6 +31484,46 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "web/node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
             }
         },
         "web/node_modules/json-schema-traverse": {
@@ -31244,6 +31581,72 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "web/node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "web/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "web/node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
+        "web/node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "web/node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "web/node_modules/typescript": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -31258,10 +31661,183 @@
             }
         },
         "web/node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
             "license": "MIT"
+        },
+        "web/node_modules/vite": {
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.3.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "web/node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "web/node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "web/node_modules/ws": {
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "web/node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
         }
     }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,11 @@
     "eject": "react-scripts eject"
   },
   "homepage": ".",
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router/dom$": "react-router/dist/development/dom-export.js"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/web/package.json
+++ b/web/package.json
@@ -9,8 +9,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.4.2",
-    "@types/jest": "^28.1.6",
-    "@types/node": "^18.6.5",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@types/styled-components": "^5.1.25",
@@ -26,7 +24,11 @@
     "typescript": "^5.4.5"
   },
   "devDependencies": {
-    "shx": "^0.3.4"
+    "@types/node": "^22.20.1",
+    "@vitejs/plugin-react": "^6.0.4",
+    "jsdom": "^26.1.0",
+    "shx": "^0.3.4",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "postinstall": "shx cp -n src/env/local.template.ts src/env/local.ts && shx cp -n src/env/local.ts src/env/env.ts",
@@ -36,16 +38,11 @@
     "build:local": "cp src/env/local.ts src/env/env.ts && react-scripts build",
     "build:dev": "cp src/env/dev.ts src/env/env.ts && react-scripts build",
     "build:prod": "cp src/env/prod.ts src/env/env.ts && react-scripts build",
-    "test": "react-scripts test --watchAll=false",
-    "test:watch": "react-scripts test",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "eject": "react-scripts eject"
   },
   "homepage": ".",
-  "jest": {
-    "moduleNameMapper": {
-      "^react-router/dom$": "react-router/dist/development/dom-export.js"
-    }
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HashRouter } from 'react-router-dom';
+import App from './App';
+
+// Guards the router integration itself: every other test mounts leaf pages
+// directly, so a react-router upgrade that breaks module resolution or
+// rendering would otherwise pass CI untouched.
+test('mounts through the router and navigates off the start page', () => {
+  render(<HashRouter><App /></HashRouter>);
+
+  expect(screen.getAllByText(/Apply for a postal vote/i).length).toBeGreaterThan(0);
+
+  fireEvent.click(screen.getByText(/Start now/i));
+
+  expect(window.location.hash).toBe('#/is-registered');
+});

--- a/web/src/pages/Start.test.tsx
+++ b/web/src/pages/Start.test.tsx
@@ -11,7 +11,7 @@ test('clicking button triggers onStart', async () => {
   const user = userEvent.setup();
 
   // Given... start page with callback
-  const onStart = jest.fn();
+  const onStart = vi.fn();
   render(<Start onStart={onStart} />);
 
   // Then... callback not automatically called

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -1,11 +1,1 @@
 import '@testing-library/jest-dom';
-
-// react-router v7 pulls in TextEncoder/TextDecoder at import time, which the
-// jsdom environment bundled with react-scripts does not define. Node has had
-// both as globals since v11; this only bridges them into jsdom.
-import { TextDecoder, TextEncoder } from 'util';
-
-if (typeof global.TextEncoder === 'undefined') {
-  global.TextEncoder = TextEncoder;
-  global.TextDecoder = TextDecoder as typeof global.TextDecoder;
-}

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+// react-router v7 pulls in TextEncoder/TextDecoder at import time, which the
+// jsdom environment bundled with react-scripts does not define. Node has had
+// both as globals since v11; this only bridges them into jsdom.
+import { TextDecoder, TextEncoder } from 'util';
+
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+  global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -18,7 +18,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": [
+      "vitest/globals",
+      "node"
+    ]
   },
   "include": [
     "src"

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+  },
+});


### PR DESCRIPTION
Two bugs found while looking into why CI was red on #51, both fixed by adopting patterns from your other repos.

## 1. CI concurrency cancelled PRs at random

The `build` job put every run in one global `deploy-dev` concurrency group. Only master pushes deploy — PR runs just build and test — so PRs contended for a slot they never needed.

`cancel-in-progress: false` didn't help: a *queued* run displaces another *queued* run in the same group. Dependabot opened three PRs within 23 seconds, the two either side won the slot, and #51 was evicted after 10s with:

> Canceling since a higher priority waiting request for deploy-dev exists

So #51's checks never ran at all — its red X was this, not the bump.

**Fix: adopt the `ci` + `deploy` two-job split from [`file-sync/node-gh-pages.yaml`](https://github.com/domdomegg/domdomegg/blob/master/file-sync/node-gh-pages.yaml).** That's how the other repos avoid this entirely — the deploy job carries the concurrency group and is gated on master, so PR runs never join it. postal-vote had merged build and deploy into one job, which is exactly why the group leaked onto every PR. Structural, matching the template, rather than a clever conditional expression that would drift.

Also picks up the template's `env: CI: true`, `--if-present` on lint/build/test, and `branches: [master]`.

⚠️ **The job rename `build` → `ci` required updating branch protection** — a required check named `build` would sit pending forever and block every merge, including Dependabot auto-merge. I've already updated master's rule to require `ci`.

Not switching to the template wholesale: this repo deploys two artifacts from one commit (server → Lambda, web → Pages), which no template covers, so the deploy steps stay bespoke.

## 2. react-router v7 breaks under Jest — so web now runs Vitest

#51 is a v6→v7 major bump, and v7 exposes `react-router/dom` **only** through its `exports` map. The Jest resolver pinned by `react-scripts` 5 predates `exports`, so anything importing `react-router-dom` dies under test:

```
Cannot find module 'react-router/dom' from 'node_modules/react-router-dom/dist/index.js'
```

Behind it, a second failure: v7 touches `TextEncoder`/`TextDecoder` at import time, which CRA's jsdom doesn't define.

I first patched around both (a `moduleNameMapper` hardcoding a path into react-router's `dist`, plus a polyfill), but that's fragile and would rot on the next upgrade. **Vitest reads `exports` natively and provides `TextEncoder`, so both workarounds just disappear** — and it matches the `server` workspace, which already runs Vitest with `globals: true`.

Verified by installing react-router v7.18.1 locally: tests and build both pass with no mapper and no polyfill. Reverted to v6 here so **#51 stays the commit that does the bump** — merge this first and #51 should go green on its own.

**Only the test runner moves.** Builds and the dev server stay on `react-scripts`; swapping the bundler is separate, larger work.

Incidental changes this forces:
- `jest.fn()` → `vi.fn()`, matching the server's bare-globals style
- Drop `@types/jest` (collides with Vitest globals) — also shrinks the bundle 166kB → 158kB
- Bump `@types/node` 18 → 22 for Vite 8's peer range; CI already runs Node 24, so 18 was stale anyway

## Why CI couldn't have caught either

The whole suite was one file, `Start.test.tsx`, which mounts a leaf component and never touches a router — so the break was invisible. This PR adds `App.test.tsx`, which renders through `HashRouter` and navigates. It's the test that caught both failures above.

## Verification

`lint`, `build`, `test` and `tsc --noEmit` all green — against **both** the current v6 and the v7 from #51.

Note `npm run lint` fails locally on `server/src/env/{dev,prod}.ts`, but those are gitignored local secrets absent in CI — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)