### PR TITLE
Bump react-router and react-router-dom to 7.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6439,15 +6439,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/@remix-run/router": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-            "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -23830,35 +23821,54 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-            "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+            "version": "7.18.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+            "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3"
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-            "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+            "version": "7.18.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+            "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3",
-                "react-router": "6.30.4"
+                "react-router": "7.18.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
+            }
+        },
+        "node_modules/react-router/node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/react-scripts": {
@@ -26104,6 +26114,12 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
+        },
+        "node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+            "license": "MIT"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -30816,7 +30832,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-hook-form": "^7.34.0",
-                "react-router-dom": "^6.3.0",
+                "react-router-dom": "^7.18.1",
                 "react-scripts": "^5.0.1",
                 "signature_pad": "^4.0.7",
                 "styled-components": "^5.3.5",

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.34.0",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "^7.18.1",
     "react-scripts": "^5.0.1",
     "signature_pad": "^4.0.7",
     "styled-components": "^5.3.5",


### PR DESCRIPTION
Completes the upgrade #51 was opened for.

Dependabot closed #51 as *"Looks like these dependencies are no longer updatable"* immediately after #53 landed — but master was still on react-router v6, so **the upgrade never actually applied**. The lockfile changes in #53 (notably the `@types/node` bump needed for Vite's peer range) seem to have confused its resolution. Rather than leave the bump silently dropped, this does it directly.

Same target version #51 proposed: `7.18.1`.

## No application code changes needed

The app only uses `HashRouter`, `Routes`, `Route`, `Link` and `useNavigate` — all unchanged across v6→v7. The diff is one line in `web/package.json` plus the lockfile.

## Verification

This is precisely the upgrade #53 was verified against, and the `App.test.tsx` router test added there is what covers it. Re-confirmed on this branch:

- `npm run test` — 4 tests across both workspaces pass, including the router mount/navigate test
- `tsc --noEmit` — clean
- `eslint` — clean
- `npm run build` — compiles successfully

Worth noting this bump would have been **red on master before #53**: the old Jest resolver couldn't handle v7's `exports` map. It's green now only because web moved to Vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)